### PR TITLE
Fix AI parsing bug

### DIFF
--- a/src/ai/remediation.py
+++ b/src/ai/remediation.py
@@ -129,13 +129,14 @@ def batch_suggest_remediation(findings: List[Dict[str, Any]], batch_size: int = 
             # Parse numbered responses from AI
             answers = []
             for line in content.split("\n"):
-                # Look for numbered list items (1. or 1))
-                if line.strip() and (line.strip()[0].isdigit() and line.strip()[1] in [".", ")"]):
-                    # Extract the content after the number
-                    answers.append(line[line.find('.')+1:].strip())
+                stripped = line.strip()
+                # Look for numbered list items like "1." or "1)" safely
+                if re.match(r"^\d[.)]", stripped):
+                    # Extract text after the number and delimiter
+                    answers.append(stripped[2:].strip())
                 elif answers:
                     # If we're already collecting an answer, this might be a continuation
-                    answers[-1] += " " + line.strip()
+                    answers[-1] += " " + stripped
             
             # Assign AI suggestions to findings
             for idx, finding in enumerate(batch):

--- a/tests/test_ai_parsing.py
+++ b/tests/test_ai_parsing.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from src.ai.remediation import batch_suggest_remediation
+
+
+def test_batch_parsing_no_index_error(monkeypatch):
+    # Prepare a fake OpenAI API response with incomplete numbered line
+    responses = [
+        {
+            "choices": [
+                {"message": {"content": "1\n2. fix second"}}
+            ]
+        }
+    ]
+    call_count = 0
+
+    def fake_post(url, headers, json, timeout):
+        nonlocal call_count
+        call_count += 1
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return responses[call_count-1]
+        return Resp()
+
+    monkeypatch.setattr("src.ai.remediation.requests.post", fake_post)
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    findings = [{"description": "a"}, {"description": "b"}]
+    batch_suggest_remediation(findings, batch_size=2)
+
+    # No IndexError occurred and at least one suggestion parsed correctly
+    assert any(f.get("ai_remediation", "").startswith("fix second") for f in findings)


### PR DESCRIPTION
## Summary
- fix index error when parsing numbered AI responses
- add regression test for AI parsing edge case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848362f2150833393d677d0e70e203e